### PR TITLE
Make version a variable and default to 1.6.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 
 helga_home: /opt/helga
 helga_nick: helga
+helga_version: 1.6.3
 helga_irc_host: localhost
 helga_irc_port: 6667
 helga_use_ssl: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   pip: name=pip virtualenv={{ helga_home }} extra_args='--upgrade'
 
 - name: Conceive the Helga.
-  pip: name=helga virtualenv={{ helga_home }} version=1.5.1
+  pip: name=helga virtualenv={{ helga_home }} version={{ helga_version }}
 
 - name: Helga enhancements.
   pip: name={{ item.src }} state=present virtualenv={{ helga_home }}


### PR DESCRIPTION
The latest versions of pip make some changes that are incompatible with
1.5.1's code.
