### PR TITLE
Bump default to helga 1.6.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 helga_home: /opt/helga
 helga_nick: helga
-helga_version: 1.6.3
+helga_version: 1.6.4
 helga_irc_host: localhost
 helga_irc_port: 6667
 helga_use_ssl: yes


### PR DESCRIPTION
A new version of helga was released that fixed errors with custom nicks.
