### PR TITLE
Add option to track the latest helga release

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ License
 
 GPLv3
 
+Variables
+---------
+ * `helga_version` - Can be set to a valid helga version number, or `latest` to always force a pip upgrade
+
 Author Information
 ------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,8 +18,13 @@
 - name: Create a virtualenv with latest pip.
   pip: name=pip virtualenv={{ helga_home }} extra_args='--upgrade'
 
-- name: Conceive the Helga.
+- name: Conceive the Helga (specific version)
   pip: name=helga virtualenv={{ helga_home }} version={{ helga_version }}
+  when: helga_version != "latest"
+
+- name: Conceive the Helga. (latest version)
+  pip: name=helga virtualenv={{ helga_home }} extra_args="--upgrade"
+  when: helga_version == "latest"
 
 - name: Helga enhancements.
   pip: name={{ item.src }} state=present virtualenv={{ helga_home }}


### PR DESCRIPTION
This change makes the role force a helga upgrade if the `helga_version`
variable is set to `latest`.  This might not be the correct Ansible way
of doing things, but it works in my testing.
