### PR TITLE
Allow pip package states to be controlled by vars.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   pip: name=helga virtualenv={{ helga_home }} version={{ helga_version }}
 
 - name: Helga enhancements.
-  pip: name={{ item.src }} state=present virtualenv={{ helga_home }}
+  pip: name={{ item.src }} state={{ item.state | default('present')}} virtualenv={{ helga_home }}
   with_items: helga_external_plugins
   notify: Wake up, Helga...
 


### PR DESCRIPTION
If a pip package is updated, and the deployer wants to keep it
up-to-date, they would manually have to remove the package to get the
new version.

Instead, this patch allows the user to override the state so that it
might be 'latest' for the ones they want. Otherwise, the default
behavior is the same.

Fixes #5
